### PR TITLE
Added secondary key to blast_query stream.

### DIFF
--- a/tap_sailthru/streams.py
+++ b/tap_sailthru/streams.py
@@ -282,7 +282,7 @@ class BlastQuery(FullTableStream):
     Docs: https://getstarted.sailthru.com/developers/api/job/#blast-query
     """
     tap_stream_id = 'blast_query'
-    key_properties = ['profile_id']
+    key_properties = ['profile_id', 'blast_id']
     params = {
         'job': 'blast_query',
         'blast_id': '{blast_id}',


### PR DESCRIPTION
# Description of change
Adding a second id to the blast query stream as a profile id can be on different blasts (campaigns).

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
